### PR TITLE
Update 02-Build-and-deploy-your-application-with-GitHub-Copilot-for-A…

### DIFF
--- a/translations/ja/06-Using-GitHub-Copilot-for-Azure-to-Deploy-to-Cloud/02-Build-and-deploy-your-application-with-GitHub-Copilot-for-Azure.md
+++ b/translations/ja/06-Using-GitHub-Copilot-for-Azure-to-Deploy-to-Cloud/02-Build-and-deploy-your-application-with-GitHub-Copilot-for-Azure.md
@@ -118,7 +118,7 @@ GitHub Copilot for Azure の回答は、大規模言語モデルがどのよう�
 
     Depending on the `azd` template that you're deploying and the location that you selected, the template might take 10 minutes (or more) to deploy. But we can Move on to [Module 3](./03-Get-Answers-to-your-Questions-about-Azure-Services-and-Resources.md) while it completes
 
-1. If `azd up` experiences an error, ask GitHub Copilot for Azure about the error and how you can resolve it.
+1. `azd up` でエラーが発生した場合は、GitHub Copilot for Azure にエラーとその解決方法を問い合わせてください。
 
     > **TIP**
     > For an easy way to attach the last terminal command results, use the paperclip icon at the bottom left of the chat pane. GitHub Copilot for Azure doesn't know the terminal command results unless they are copy/pasted or attached via the paperclip.


### PR DESCRIPTION
…zure.md (Untranslated "If `azd up` experiences an error,～")

https://github.com/microsoft/mastering-github-copilot-for-dotnet-csharp-developers/blob/main/translations/ja/06-Using-GitHub-Copilot-for-Azure-to-Deploy-to-Cloud/02-Build-and-deploy-your-application-with-GitHub-Copilot-for-Azure.md #PingMSFTDocs